### PR TITLE
Use space for scope separator

### DIFF
--- a/src/Provider/Ebay.php
+++ b/src/Provider/Ebay.php
@@ -358,6 +358,14 @@ class Ebay extends AbstractProvider
     }
 
     /**
+     * @return string
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+    /**
      * @return array
      */
     public function getLocaleToDefaultGlobalIdMap()


### PR DESCRIPTION
Hi Neil

I've been using the library, but found in the documentation that the scope separator needs to be a space rather than the default comma.  

regards

Steve